### PR TITLE
Removed sys.exit(1) when plot.bgcolour = None.

### DIFF
--- a/rxnlvl/__init__.py
+++ b/rxnlvl/__init__.py
@@ -68,7 +68,6 @@ class plot():
             )
         except AssertionError as e:
             sys.stderr.write(str(e))
-            sys.exit(1)
         self.qualified = qualified
         try:
             assert vbuf > 0 and hbuf > 0,\


### PR DESCRIPTION
In README.md, it says that setting plot.bgcolour to None will
result in a transparent background. However, an assert lead to
sys.exit(1) if plot.bgcolour was None.

I left the assert and the exception message, but simply removed
the sys.exit(1). Now, when plot.bgcolour is None, it throws a
warning but continues on to produce the plot with a transparent
background.
